### PR TITLE
Adding ORNL and BNL repo groups to the Institutions/National Labs category

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ and then subtopics. Please feel free to suggest a new project, or update the org
 
  - [SLAC](https://github.com/slaclab) National Accelerator Laboratory
  - [LINAC Coherent Light Source](https://github.com/slac-lcls/) at SLAC for experiments with High Energy Physics, Materials Science, Biologists, etc.
+ - [ORNL](https://github.com/ORNL/) Oak Ridge National Laboratory
+ - [OLCF](https://github.com/OLCF/) Oak Ridge Leadership Computing Facility
+ - [BNL](https://github.com/BrookhavenNationalLaboratory/) Brookhaven National Laboratory
+ - [BNL-SDCC](https://github.com/bnl-sdcc/) Brookhaven National Laboratory Scientific Data and Computing Center
+ - [NSLS-II](https://github.com/NSLS-II) National Synchrotron Light Source II at Brookhaven National Laboratory
+ - [BNL-NPP](https://github.com/BNLNPPS) Brookhaven National Laboratory Nuclear and Particle Physics Software Group
 
 ## Neuroscience
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ and then subtopics. Please feel free to suggest a new project, or update the org
 
 ### National Labs
 
- - [SLAC](http://github.com/slaclab) National Accelerator Laboratory
+ - [SLAC](https://github.com/slaclab) National Accelerator Laboratory
  - [LINAC Coherent Light Source](https://github.com/slac-lcls/) at SLAC for experiments with High Energy Physics, Materials Science, Biologists, etc.
 
 ## Neuroscience


### PR DESCRIPTION
Work included: 
 - Added relevant Oak Ridge National Lab (ORNL) and Brookhaven National Lab (BNL) repo groups that are currently actively developed.
 - Switched SLAC entry from `http` -> `https` to avoid a redirect (probably doesn't matter much

These are all groups so I didn't add any specific repos to the `.github/repos.txt` for the "good first issues" page.