### PR TITLE
Added new Materials Science category and Neutron Scattering section + repo groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ If you want to get involved with science and research software engineering, this
  - [Geoscience](#geoscience)
  - [High Performance Computing](#high-performance-computing)
  - [Institutions](#institutions)
-   - [Academic Groups](#academic-groups) 
-   - [Academic Labs](#academic-labs) 
-   - [National Labs](#national-labs) 
+   - [Academic Groups](#academic-groups)
+   - [Academic Labs](#academic-labs)
+   - [National Labs](#national-labs)
+ - [Materials Science](#materials-science)
+   - [Neutron Scattering](#neutron-scattering)
  - [Neuroscience](#neuroscience)
  - [Psychology](#psychology)
  - [Reproducible Science](#reproducible-science)
@@ -72,6 +74,13 @@ and then subtopics. Please feel free to suggest a new project, or update the org
 
  - [SLAC](http://github.com/slaclab) National Accelerator Laboratory
  - [LINAC Coherent Light Source](https://github.com/slac-lcls/) at SLAC for experiments with High Energy Physics, Materials Science, Biologists, etc.
+
+## Materials Science
+
+### Neutron Scattering
+
+ - [Mantid Project](https://github.com/mantidproject) Framework for analysis and visualization of neutron scattering and muon spectroscopy data
+ - [neutrons](https://github.com/neutrons) Neutron Scattering Softwares, mainly for [ORNL Facilities](https://neutrons.ornl.gov/)
 
 ## Neuroscience
 


### PR DESCRIPTION
Work:
 - Added Materials Science category
 - Added Materials Science/Neutron Scattering section
 - Add Mantid and Neutrons to this section (links below)

Let me know if this should be moved, wasn't exactly sure. Originally, had Neutron Scattering on its own but seems like a sub-category, not a main. Thanks!

May follow up with adding stuff to `.github/repos.txt` for good first issues in a follow-up PR.

Links:
 - https://github.com/mantidproject
 - https://github.com/neutrons